### PR TITLE
Fixed the header layout

### DIFF
--- a/src/app/core/header/header.component.html
+++ b/src/app/core/header/header.component.html
@@ -1,8 +1,8 @@
 <nav class="navbar navbar-expand bg-dark navbar-dark fixed-top">
-  <div class="container-fluid">
-    <a routerLink="/" class="navbar-brand">{{ "{csfin}" }}</a>
+  <div class="d-flex align-items-center">
+    <a routerLink="/" class="navbar-brand ms-2 me-1 my-0 p-1">{{ "{csfin}" }}</a>
 
-    <ul class="navbar-nav">
+    <ul class="navbar-nav ms-1 me-auto my-0 p-1">
       <li class="nav-item">
         <a class="nav-link" routerLink="/dashboard">Dashboard</a>
       </li>

--- a/src/app/shared/models/index.ts
+++ b/src/app/shared/models/index.ts
@@ -1,4 +1,3 @@
 export { PerformanceEvaluationItem, PerformanceEvaluationItemAdapter, PerformanceInterval } from "./evaluation.model";
 export { Exchange, ExchangeAdapter } from "./exchange.model";
 export { Security, SecurityAdapter, SecurityType, securityTypeFromString } from "./security.model";
-


### PR DESCRIPTION
- apparently some margin and padding names have changed in Bootstrap 5,
  e.g. ml (margin-left) becomes ms (margin-start) and mr (margin-right)
  becomes me (margin-end)

Resolves #3