### PR TITLE
Fix select element display

### DIFF
--- a/src/app/modules/evaluation/performance/performance.component.html
+++ b/src/app/modules/evaluation/performance/performance.component.html
@@ -8,7 +8,7 @@
           <div class="p-2">
             <select
               id="interval-selector"
-              class="form-control"
+              class="form-select"
               [formControl]="intervalSelector"
               (ngModelChange)="onChange($event)"
             >


### PR DESCRIPTION
Apparently the select element needs a different class "form-select" in Bootstrap 5. With the new class the dropdown indicator is back!